### PR TITLE
compare containerd runtime to variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,7 @@ EOF
 
 configure_runtime(){
   local runtime="$1"
-  if [ "runtime" = "containerd" ]; then
+  if [ "${runtime}" = "containerd" ]; then
     # remove potential disabled cri line
     containerd config default | grep -v '^\s*disabled_plugins.*"cri"' > /etc/containerd/config.toml
     systemctl restart containerd


### PR DESCRIPTION
We were comparing `"runtime" = "containerd"` instead of `"${runtime}" = "containerd"`. Oops.